### PR TITLE
tool tips for bases with battle cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,34 @@ Execution of the unit tests is done by:
 cd unittests
 make
 
+Adding an army
+--------------
+
+A base in army is defined as a table.  We call this table the "base definition".
+
+Base definition fields are:
+* name Augmented type of the base. Starts with the type, e.g. "Knights".  
+  Can have a suffix added to indicate a general "_Gen".
+  Can have a suffix added to indicate mounted infantry "_Mounted".
+* base Tile tht the figures are to be placed on when rendering.
+* n_modelsa Number of models to place on the base
+* fixed_models Figures to add to the base when rendering.
+* loose = true (optional) Indictes that the models should be placed in a 
+    non-grid formation.  Used to indicate open order troops.
+* points (optional) Number of points the base is worth. Default is the points for the type.
+* battle_card (optional) Battle card that modifies the standard behviour of the type
+
+A base definition that has points or battle_card set must be an external 
+base definition, otherwise it may be external or internal.
+
+An external base definition is one in which a variable is declared for the definition.
+See burgundian_ordannances_1471_to_1477_ad_knights_gen for an example.
+
+An army is declared with data for the army, and its bases.  For an external
+base definition the definition is a string of the variable name.  Example:
+base1 = "burgundian_ordannances_1471_to_1477_ad_knights_gen",
+
+An internal base defintion is just the table itself.  Internal definitions will take
+a tiny amount of less memory.
+
+

--- a/README.md
+++ b/README.md
@@ -61,10 +61,15 @@ Base definition fields are:
 * fixed_models Figures to add to the base when rendering.
 * loose = true (optional) Indictes that the models should be placed in a 
     non-grid formation.  Used to indicate open order troops.
-* points (optional) Number of points the base is worth. Default is the points for the type.
-* battle_card (optional) Battle card that modifies the standard behviour of the type
+* points (optional) Number of points the base is worth. Default is the points 
+  for the type.
+* battle_card (optional) Battle card that modifies the standard behviour of 
+  the type
+* dismount_as (optional) String containing the name of the variable for
+  the base defintion of that will replace this base if the unit
+  is dismounted.  i.e. The base is mobile infantry.
 
-A base definition that has points or battle_card set must be an external 
+A base definition that has points, battle_card, or dismount_as set must be an external 
 base definition, otherwise it may be external or internal.
 
 An external base definition is one in which a variable is declared for the definition.

--- a/main.ttslua
+++ b/main.ttslua
@@ -29,7 +29,17 @@
 #include scripts/logic
 #include scripts/uievents
 
-function onload()
+-- Extra information that is to be persisted.
+-- key is object GUID, value is a table of the properties for the object.
+g_decorations = {}
+
+function onSave()
+  local saved_data = JSON.encode(g_decorations)
+  return saved_data
+end
+
+
+function onload(saved_data)
     print_info('\n---------------------------------\nTriumph! v 1.0 build 20210313\n---------------------------------\n\nCheck the Notebook for instructions.')
     Wait.time(main_loop, g_seconds_main_loop, -1)
     make_scenery_non_interactable()
@@ -38,7 +48,23 @@ function onload()
     spawn_all_dice()
     spawn_dead_zones()
     print_tool_tip_status()
+    restore_extra_data(saved_data)
 end
+
+function restore_extra_data(saved_data)
+  if saved_data == nil then
+    return
+  end
+  local extra = JSON.decode(saved_data)
+  if extra == nil then
+    return
+  end
+  if type(extra) ~= 'table' then
+    return
+  end
+  g_decorations = extra
+end
+
 
 function make_scenery_non_interactable()
     -- Main table

--- a/scripts/data/data_armies_Medieval_Era.ttslua
+++ b/scripts/data/data_armies_Medieval_Era.ttslua
@@ -146,47 +146,47 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
     },
 
     -- Knights 2-4, Deployment Dismountable to Elite foot
-    base1 = burgundian_ordannances_1471_to_1477_ad_knights_gen,
-    base2 = burgundian_ordannances_1471_to_1477_ad_knights,
-    base3 = burgundian_ordannances_1471_to_1477_ad_knights,
-    base4 = burgundian_ordannances_1471_to_1477_ad_knights,
+    base1 = "burgundian_ordannances_1471_to_1477_ad_knights_gen",
+    base2 = "burgundian_ordannances_1471_to_1477_ad_knights",
+    base3 = "burgundian_ordannances_1471_to_1477_ad_knights",
+    base4 = "burgundian_ordannances_1471_to_1477_ad_knights",
     -- or
-    base5 = burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted,
-    base6 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
-    base7 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
-    base8 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
+    base5 = "burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted",
+    base6 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted",
+    base7 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted",
+    base8 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted",
     -- or
-    base9 = burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted,
-    base10 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
-    base11 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
-    base12 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
+    base9 = "burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted",
+    base10 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted",
+    base11 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted",
+    base12 = "burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted",
 
     -- 1 or 2 artillery
-    base13 = burgundian_ordannances_1471_to_1477_ad_artillery,
-    base14 = burgundian_ordannances_1471_to_1477_ad_artillery,
+    base13 = "burgundian_ordannances_1471_to_1477_ad_artillery",
+    base14 = "burgundian_ordannances_1471_to_1477_ad_artillery",
 
     -- 2 to 4 archers, can be mobile infantry
-    base15 = burgundian_ordannances_1471_to_1477_ad_archers,
-    base16 = burgundian_ordannances_1471_to_1477_ad_archers,
-    base17 = burgundian_ordannances_1471_to_1477_ad_archers,
-    base18 = burgundian_ordannances_1471_to_1477_ad_archers,
+    base15 = "burgundian_ordannances_1471_to_1477_ad_archers",
+    base16 = "burgundian_ordannances_1471_to_1477_ad_archers",
+    base17 = "burgundian_ordannances_1471_to_1477_ad_archers",
+    base18 = "burgundian_ordannances_1471_to_1477_ad_archers",
     -- or
-    base19 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
-    base20 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
-    base21 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
-    base22 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
+    base19 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted",
+    base20 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted",
+    base21 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted",
+    base22 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted",
     -- or
-    base23 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
-    base24 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
-    base25 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
-    base25 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
+    base23 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted",
+    base24 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted",
+    base25 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted",
+    base25 = "burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted",
 
     -- 1 to 2 pikes or pavisiers
-    base26 = burgundian_ordannances_1471_to_1477_ad_pikes, 
-    base27 = burgundian_ordannances_1471_to_1477_ad_pikes, 
-    -- or 
-    base28 = burgundian_ordannances_1471_to_1477_ad_pavisiers,
-    base29 = burgundian_ordannances_1471_to_1477_ad_pavisiers,
+    base26 = "burgundian_ordannances_1471_to_1477_ad_pikes",
+    base27 = "burgundian_ordannances_1471_to_1477_ad_pikes", 
+    -- or
+    base28 = "burgundian_ordannances_1471_to_1477_ad_pavisiers",
+    base29 = "burgundian_ordannances_1471_to_1477_ad_pavisiers",
 
     -- 0 to 1 Skimishers
     base30 = {

--- a/scripts/data/data_armies_Medieval_Era.ttslua
+++ b/scripts/data/data_armies_Medieval_Era.ttslua
@@ -1,14 +1,11 @@
 armies["Medieval"] = {}
 
-armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
-    data = {
-        Invasion = 4,
-        maneuver = 0,
-        terrain = 'Arable',
-        list = 'Mandatory: 2 x Knights (dism. as EF), 1 x Artillery, 2 x Archers (Mobile), 1 x Pikes of Pavisiers.',
-        general = 'General: Knights.'
-    },
-    base1 = {
+-- Burgundian Ordonnance
+-- 1471 AD to 1477 AD
+-- https://meshwesh.wgcwar.com/armyList/5fb1b9e8e1af060017709c95/explore
+-- As of: 20210315
+burgundian_ordannances_1471_to_1477_ad_knights_gen =
+    {
         name = 'Knights_Gen',
         base = 'tile_grass_40x30',
         n_models = 3,
@@ -16,9 +13,43 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
             [1] = 'troop_knight_burgundian_ordonnances',
             [2] = 'troop_knight_burgundian_ordonnances_captain',
             [3] = 'troop_knight_burgundian_ordonnances_bannerman'
-        }
-    },
-    base2 = {
+        },
+        points=4
+    }
+burgundian_ordannances_1471_to_1477_ad_knights =
+    {
+        name = 'Knights',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_burgundian_ordonnances',
+        points=4
+    }
+
+burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted =
+    {
+        name = 'Knights_Gen',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_knight_burgundian_ordonnances',
+            [2] = 'troop_knight_burgundian_ordonnances_captain',
+            [3] = 'troop_knight_burgundian_ordonnances_bannerman'
+        },
+        points=4.5,
+        battle_card="Deployment Dismounting"
+    }
+burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted =
+    {
+        name = 'Knights',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_burgundian_ordonnances',
+        points=4.5,
+        battle_card="Deployment Dismounting"
+    }
+
+burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted =
+    {
         name = 'Elite Foot_Gen',
         base = 'tile_grass_40x15',
         n_models = 4,
@@ -27,21 +58,23 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
             [2] = 'troop_pikeman_burgundian_ordonnances_bannerman',
             [3] = 'troop_pikeman_burgundian_ordonnances_captain',
             [4] = 'troop_swordman_two_handed_burgundian_ordonnances'
-        }
-    },
-    base3 = {
-        name = 'Knights',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_burgundian_ordonnances'
-    },
-    base4 = {
+        },
+        points=4.5,
+        battle_card="Deployment Dismounting"
+    }
+burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted =
+    {
         name = 'Elite Foot',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_swordman_two_handed_burgundian_ordonnances'
-    },
-    base5 = {
+        model_data = 'troop_swordman_two_handed_burgundian_ordonnances',
+        points=4.5,
+        battle_card="Deployment Dismounting"
+    }
+
+
+burgundian_ordannances_1471_to_1477_ad_artillery =
+    {
         name = 'Artillery',
         base = 'tile_grass_40x40',
         n_models = 3,
@@ -50,38 +83,43 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
             [2] = 'troop_artillery_pieces_burgundian_ordonnances',
             [3] = 'troop_artillery_crew_burgundian_ordonnances'
         }
-    },
-    base6 = {
+    }
+
+burgundian_ordannances_1471_to_1477_ad_archers =
+    {
         name = 'Archers',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_burgundian_ordonnances'
-    },
-    base7 = {
+    }
+burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted =
+    {
         name = 'Archers_Mobile',
         base = 'tile_grass_40x40',
         n_models = 4,
         model_data = 'troop_horse_rider_burgundian_ordonnances'
-    },
-    base8 = {
+    }
+
+burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted =
+    {
         name = 'Archers',
         base = 'tile_grass_40x20',
         n_models = 4,
-        model_data = 'troop_longbowman_burgundian_ordonnances'
-    },
-    base9 = {
-        name = 'Archers_Mobile',
-        base = 'tile_grass_40x40',
-        n_models = 4,
-        model_data = 'troop_horse_rider_burgundian_ordonnances'
-    },
-    base10 = {
+        model_data = 'troop_crossbowman_burgundian_ordonnances',
+        points=4.5,
+        battle_card="Mobile Infantry",
+    }
+
+
+burgundian_ordannances_1471_to_1477_ad_pikes =
+    {
         name = 'Pikes',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_burgundian_ordonnances_straight'
-    },
-    base11 = {
+    }
+burgundian_ordannances_1471_to_1477_ad_pavisiers =
+    {
         name = 'Pavisiers',
         base = 'tile_grass_40x40',
         n_models = 8,
@@ -95,140 +133,125 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
             [7] = 'troop_pikeman_burgundian_ordonnances_inclined',
             [8] = 'troop_pikeman_burgundian_ordonnances_inclined'
         }
+    }
+
+
+armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
+    data = {
+        Invasion = 4,
+        maneuver = 0,
+        terrain = 'Arable',
+        list = 'Mandatory: 2 x Knights (dism. as EF), 1 x Artillery, 2 x Archers (Mobile), 1 x Pikes of Pavisiers.',
+        general = 'General: Knights.'
     },
-    base12 = {
-        name = 'Knights',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_burgundian_ordonnances'
-    },
-    base13 = {
-        name = 'Elite Foot',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_burgundian_ordonnances'
-    },
-    base14 = {
-        name = 'Knights',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_burgundian_ordonnances'
-    },
-    base15 = {
-        name = 'Elite Foot',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_burgundian_ordonnances'
-    },
-    base16 = {
-        name = 'Artillery',
-        base = 'tile_grass_40x40',
-        n_models = 3,
-        fixed_models = {
-            [1] = 'troop_artillery_crew_burgundian_ordonnances',
-            [2] = 'troop_artillery_pieces_burgundian_ordonnances',
-            [3] = 'troop_artillery_crew_burgundian_ordonnances'
-        }
-    },
-    base17 = {
-        name = 'Archers',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_burgundian_ordonnances'
-    },
-    base18 = {
-        name = 'Archers_Mobile',
-        base = 'tile_grass_40x40',
-        n_models = 4,
-        model_data = 'troop_horse_rider_burgundian_ordonnances'
-    },
-    base19 = {
-        name = 'Archers',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_burgundian_ordonnances'
-    },
-    base20 = {
-        name = 'Archers_Mobile',
-        base = 'tile_grass_40x40',
-        n_models = 4,
-        model_data = 'troop_horse_rider_burgundian_ordonnances'
-    },
-    base21 = {
-        name = 'Pikes',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_burgundian_ordonnances_straight'
-    },
-    base22 = {
-        name = 'Pavisiers',
-        base = 'tile_grass_40x40',
-        n_models = 8,
-        fixed_models = {
-            [1] = 'troop_longbowman_burgundian_ordonnances',
-            [2] = 'troop_longbowman_burgundian_ordonnances',
-            [3] = 'troop_longbowman_burgundian_ordonnances',
-            [4] = 'troop_longbowman_burgundian_ordonnances',
-            [5] = 'troop_pikeman_burgundian_ordonnances_inclined',
-            [6] = 'troop_pikeman_burgundian_ordonnances_inclined',
-            [7] = 'troop_pikeman_burgundian_ordonnances_inclined',
-            [8] = 'troop_pikeman_burgundian_ordonnances_inclined'
-        }
-    },
-    base23 = {
+
+    -- Knights 2-4, Deployment Dismountable to Elite foot
+    base1 = burgundian_ordannances_1471_to_1477_ad_knights_gen,
+    base2 = burgundian_ordannances_1471_to_1477_ad_knights,
+    base3 = burgundian_ordannances_1471_to_1477_ad_knights,
+    base4 = burgundian_ordannances_1471_to_1477_ad_knights,
+    -- or
+    base5 = burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted,
+    base6 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
+    base7 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
+    base8 = burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted,
+    -- or
+    base9 = burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted,
+    base10 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
+    base11 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
+    base12 = burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted,
+
+    -- 1 or 2 artillery
+    base13 = burgundian_ordannances_1471_to_1477_ad_artillery,
+    base14 = burgundian_ordannances_1471_to_1477_ad_artillery,
+
+    -- 2 to 4 archers, can be mobile infantry
+    base15 = burgundian_ordannances_1471_to_1477_ad_archers,
+    base16 = burgundian_ordannances_1471_to_1477_ad_archers,
+    base17 = burgundian_ordannances_1471_to_1477_ad_archers,
+    base18 = burgundian_ordannances_1471_to_1477_ad_archers,
+    -- or
+    base19 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
+    base20 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
+    base21 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
+    base22 = burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted,
+    -- or
+    base23 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
+    base24 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
+    base25 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
+    base25 = burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted,
+
+    -- 1 to 2 pikes or pavisiers
+    base26 = burgundian_ordannances_1471_to_1477_ad_pikes, 
+    base27 = burgundian_ordannances_1471_to_1477_ad_pikes, 
+    -- or 
+    base28 = burgundian_ordannances_1471_to_1477_ad_pavisiers,
+    base29 = burgundian_ordannances_1471_to_1477_ad_pavisiers,
+
+    -- 0 to 1 Skimishers
+    base30 = {
         name = 'Skirmishers',
         base = 'tile_grass_40x20',
         n_models = 2,
         model_data = 'troop_handgunner_burgundian_ordonnances'
     },
-    base24 = {
+
+    -- 0 to 2 Knights -- italian men_at_arms
+    base31 = {
         name = 'Knights',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_knight_late_medieval'
     },
-    base25 = {
+    base32 = {
         name = 'Knights',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_knight_late_medieval'
     },
-    base26 = {
+
+    -- 0 to 1 Bad Horse -- italian crossbowmen on horses
+    base33 = {
         name = 'Bad Horse',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_horse_rider_late_medieval'
     },
-    base27 = {
+
+    -- 0 to1 archers -- italian crossbowmen
+    base34 = {
         name = 'Archers',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_late_medieval'
     },
-    base28 = {
+
+    -- 0 to 4 Pikes -- Low Countries Pikesmen
+    base35 = {
         name = 'Pikes',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_late_medieval_straight'
     },
-    base29 = {
+    base36 = {
         name = 'Pikes',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_late_medieval_inclined'
     },
-    base30 = {
+    base37 = {
         name = 'Pikes',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_late_medieval_straight'
     },
-    base31 = {
+    base3r = {
         name = 'Pikes',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_late_medieval_inclined'
     },
+
     base32 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
@@ -236,6 +259,9 @@ armies["Medieval"]["Burgundian Ordonnances 1471 to 1477 AD"] = {
         model_data = 'troop_camp_burgundian_ordonnances'
     }
 }
+
+
+
 
 armies["Medieval"]["Early Renaissance Swiss 1478 to 1522 AD"] = {
     data = {

--- a/scripts/data/data_armies_Medieval_Era.ttslua
+++ b/scripts/data/data_armies_Medieval_Era.ttslua
@@ -27,7 +27,7 @@ burgundian_ordannances_1471_to_1477_ad_knights =
 
 burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted =
     {
-        name = 'Knights_Gen',
+        name = 'Knights_Gen*',
         base = 'tile_grass_40x30',
         n_models = 3,
         fixed_models = {
@@ -40,7 +40,7 @@ burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted =
     }
 burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted =
     {
-        name = 'Knights',
+        name = 'Knights*',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_knight_burgundian_ordonnances',
@@ -50,7 +50,7 @@ burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted =
 
 burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted =
     {
-        name = 'Elite Foot_Gen',
+        name = 'Elite Foot_Gen*',
         base = 'tile_grass_40x15',
         n_models = 4,
         fixed_models = {
@@ -64,7 +64,7 @@ burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted =
     }
 burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted =
     {
-        name = 'Elite Foot',
+        name = 'Elite Foot*',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_swordman_two_handed_burgundian_ordonnances',
@@ -94,15 +94,16 @@ burgundian_ordannances_1471_to_1477_ad_archers =
     }
 burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted =
     {
-        name = 'Archers_Mobile',
+        name = 'Archers_Mobile*',
         base = 'tile_grass_40x40',
         n_models = 4,
-        model_data = 'troop_horse_rider_burgundian_ordonnances'
+        model_data = 'troop_horse_rider_burgundian_ordonnances',
+        battle_card = "Mobile Infantry"
     }
 
 burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted =
     {
-        name = 'Archers',
+        name = 'Archers*',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_burgundian_ordonnances',

--- a/scripts/data/data_armies_Medieval_Era.ttslua
+++ b/scripts/data/data_armies_Medieval_Era.ttslua
@@ -36,7 +36,8 @@ burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_mounted =
             [3] = 'troop_knight_burgundian_ordonnances_bannerman'
         },
         points=4.5,
-        battle_card="Deployment Dismounting"
+        battle_card="Deployment Dismounting",
+        dismount_as="burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted"
     }
 burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted =
     {
@@ -45,7 +46,8 @@ burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted =
         n_models = 3,
         model_data = 'troop_knight_burgundian_ordonnances',
         points=4.5,
-        battle_card="Deployment Dismounting"
+        battle_card="Deployment Dismounting",
+        dismount_as="burgundian_ordannances_1471_to_1477_ad_knights_dd_dismounted"
     }
 
 burgundian_ordannances_1471_to_1477_ad_knights_gen_dd_dismounted =
@@ -98,7 +100,8 @@ burgundian_ordannances_1471_to_1477_ad_archers_mi_mounted =
         base = 'tile_grass_40x40',
         n_models = 4,
         model_data = 'troop_horse_rider_burgundian_ordonnances',
-        battle_card = "Mobile Infantry"
+        battle_card = "Mobile Infantry",
+        dismount_as="burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted"
     }
 
 burgundian_ordannances_1471_to_1477_ad_archers_mi_dismounted =

--- a/scripts/logic_spawn_army.ttslua
+++ b/scripts/logic_spawn_army.ttslua
@@ -208,7 +208,22 @@ function spawn_base(base, pos, y_rotation, is_red_player, command_color)
 
     base_obj.setRotation({0, y_rotation, 0})
     base_obj.auto_raise = false
+    return base_obj
 end
+
+-- Get the definition for a base
+-- base_data:  If string is the name of the variable holding the definition,
+--    otherwise it is the definition.
+function get_base_definition(base_data)
+  if type(base_data) == "string" then
+      -- The string refers to the name of the variable that
+      -- defines the base.
+      base_data = _G[base_data]
+    end
+    return base_data
+end
+
+
 
 -- Given an army object data, spawns it on the center of the table.
 -- Hope nothing is in there and that all data is correct because this doesn't
@@ -238,6 +253,7 @@ function spawn_army(army_name, army, is_red_player, command_color)
     local i = 0
     for base_id, base_data in pairs(army) do
         if base_id ~= 'data' then
+           base_data = get_base_definition(base_data)
             local z_pos_modifier = -1 * get_depth_base(base_data['base']) / 2
             if is_red_player then
                 z_pos_modifier = -1 * z_pos_modifier

--- a/scripts/logic_spawn_army.ttslua
+++ b/scripts/logic_spawn_army.ttslua
@@ -214,15 +214,20 @@ end
 -- Get the definition for a base
 -- base_data:  If string is the name of the variable holding the definition,
 --    otherwise it is the definition.
+-- return: table defining the base
 function get_base_definition(base_data)
-  if type(base_data) == "string" then
-      -- The string refers to the name of the variable that
-      -- defines the base.
-      base_data = _G[base_data]
-    end
+  if type(base_data) ~= "string" then
     return base_data
+  end
+  -- The string refers to the name of the variable that
+  -- defines the base.
+  local definition = _G[base_data]
+  if nil == definition then
+    print_error("base definition missing: " .. tostring(base_data))
+  end
+  definition.base_definition_name = base_data
+  return definition
 end
-
 
 
 -- Given an army object data, spawns it on the center of the table.
@@ -253,24 +258,28 @@ function spawn_army(army_name, army, is_red_player, command_color)
     local i = 0
     for base_id, base_data in pairs(army) do
         if base_id ~= 'data' then
-           base_data = get_base_definition(base_data)
-            local z_pos_modifier = -1 * get_depth_base(base_data['base']) / 2
-            if is_red_player then
-                z_pos_modifier = -1 * z_pos_modifier
+
+            local base_definition = get_base_definition(base_data)
+            if nil ~= base_definition then
+              local z_pos_modifier = -1 * get_depth_base(base_definition['base']) / 2
+              if is_red_player then
+                  z_pos_modifier = -1 * z_pos_modifier
+              end
+
+              local column = i % g_max_bases_row
+              local row = math.floor(i / g_max_bases_row)
+
+              local row_z_pos = z_pos * (1 + row) + z_pos_0
+
+              local location = {
+                  x = g_offset_deployment_x + column * g_base_width_in_inches - width_army / 2,
+                  y = g_base_height_tabletop + g_table_thickness + g_base_height_inches / 2,
+                  z = row_z_pos - z_pos_modifier
+              }
+              local base_obj = spawn_base(base_definition, location, y_rotation, is_red_player, command_color)
+              g_decorations[base_obj.getGUID()] = {base_definition_name = base_definition['base_definition_name']}
+              i = i + 1
             end
-
-            local column = i % g_max_bases_row
-            local row = math.floor(i / g_max_bases_row)
-
-            local row_z_pos = z_pos * (1 + row) + z_pos_0
-
-            local location = {
-                x = g_offset_deployment_x + column * g_base_width_in_inches - width_army / 2,
-                y = g_base_height_tabletop + g_table_thickness + g_base_height_inches / 2,
-                z = row_z_pos - z_pos_modifier
-            }
-            spawn_base(base_data, location, y_rotation, is_red_player, command_color)
-            i = i + 1
         end
     end
 
@@ -335,6 +344,7 @@ function update_authors_text(army)
     for base_id, base in pairs(army) do
         print_debug('Getting data of base for author of ' .. base_id)
         if base_id ~= 'data' then
+            base = get_base_definition(base)
             local author = get_author_base(base)
 
             if authors_set[author] == nil then

--- a/scripts/logic_spawn_army.ttslua
+++ b/scripts/logic_spawn_army.ttslua
@@ -2,6 +2,43 @@
 g_base_index = 1
 g_bases = {}
 
+-- If the base is dismountable add a menu item to dismount
+-- the base
+function add_dismount_context_menu_base(base_obj, is_red_player, command_color)
+  local definition = get_base_definition_from_base_obj(base_obj)
+  if nil == definition then
+    return
+  end
+  local dismount_as = definition['dismount_as']
+  if nil == dismount_as then
+    return
+  end
+  local dismounted_definition = get_base_definition(dismount_as)
+  if nil == dismounted_definition then
+    return
+  end
+
+  local decorations = g_decorations[base_obj.getGUID()]
+  if nil == decorations then
+    return
+  end
+  local is_red_player = decorations['is_red_player']
+  local command_color = decorations['command_color']
+
+  base_obj.addContextMenuItem('Dismount', function()
+    local old_name = base_obj.getName()
+    local pos = base_obj.getPosition()
+    local rotation = base_obj.getRotation()
+    local y_rotation = rotation.y
+    base_obj.destruct()
+
+    local new_obj = spawn_base(dismounted_definition, pos, y_rotation,
+      is_red_player, command_color)
+    local new_name = new_obj.getName()
+    print_info("Dismounted " .. old_name .. " as " .. new_name)
+  end)
+end
+
 function add_context_menu_base(base_obj)
     base_obj.clearContextMenu()
     base_obj.addContextMenuItem("Move forward single", function()
@@ -24,6 +61,7 @@ function add_context_menu_base(base_obj)
     base_obj.addContextMenuItem("Make General", function()
         make_general(base_obj)
     end)
+    add_dismount_context_menu_base(base_obj)
     base_obj.addContextMenuItem('Toggle tool tips', function()
         toggle_tool_tips()
     end)
@@ -63,6 +101,7 @@ function on_clone(source_obj, new_obj)
         is_red_player = g_bases[name]['is_red_player']
     }
     new_obj.clearContextMenu()
+    g_decorations[new_obj.getGUID()] = deep_copy(g_decorations[source_obj.getGUID()])
     add_context_menu_base(new_obj)
 
 end
@@ -88,6 +127,96 @@ function onObjectSpawn(new_obj)
     end
 end
 
+-- add models to base object
+-- base_name: Name of the base, e.g. "Camp"
+-- base_obj: base object
+-- base: definition of the base
+-- is_player_red: red or blue base
+-- pos Location of the base.
+-- y_rotation: rotation of the base
+function add_models(base_name, base, base_obj, is_red_player, pos, y_rotation)
+  local n = base['n_models']
+  if n == 0 then
+      base_obj.setRotation({0, y_rotation, 0})
+      base_obj.auto_raise = false
+      return
+  end
+
+  local depth = get_depth_base(base['base'])
+  local half_depth = depth / 2
+  local half_width = g_base_width_in_inches / 2
+
+  local rows = 1
+  local columns = n
+  if n > 4 then
+      rows = math.floor(math.sqrt(n))
+      columns = math.ceil(n/rows)
+  end
+
+  local column_width = g_base_width_in_inches / (columns + 1)
+  local row_depth = depth / (rows + 1)
+
+  local model_name = base['model_data']
+  local meshes = {}
+
+  -- If the element has multiple nonfixed element, select randomly without
+  -- repeating
+  if model_name ~= nil then
+      meshes = calculate_random_meshes(n, _G[model_name]['mesh'])
+  end
+
+  for i=1,n do
+      local column = (i - 1) % columns + 1
+      local row = math.floor((i - 1) / columns) + 1
+
+      local random_rotation = math.random(0, 40) - 20
+      if str_has_substr(base_name, 'Camp') then
+          random_rotation = 0
+      end
+
+      local random_x = 0
+      local random_z = 0
+      if base['loose'] == true then
+          random_x = random_float(-g_max_loose_spawn, g_max_loose_spawn)
+          random_z = random_float(-g_max_loose_spawn, g_max_loose_spawn)
+      end
+
+      local relative_pos = {
+          x = pos['x'] + column * column_width - half_width + random_x,
+          y = pos['y'] + g_base_height_inches / 2,
+          z = pos['z'] + row * row_depth - half_depth + random_x
+      }
+
+      local this_model_name = model_name
+      local soldier_obj = nil
+      if this_model_name ~= nil then
+          -- The object has non-fixed models, so we use any of the
+          -- randomly selected meshes
+          soldier_obj = spawn_model(this_model_name, relative_pos, random_rotation, minimal_collider, is_red_player, nil, meshes[i])
+      else
+          -- Now we have fixed models, so we use the corresponding one
+          -- Except that fixed models may use assets instead of meshes!
+          this_model_name = base['fixed_models'][i]
+          if _G[this_model_name]['customasset'] ~= nil then
+              soldier_obj = spawn_asset(this_model_name, relative_pos, random_rotation)
+          else
+              meshes[i] = random_element(_G[this_model_name]['mesh'])
+              soldier_obj = spawn_model(this_model_name, relative_pos, random_rotation, minimal_collider, is_red_player, nil, meshes[i])
+          end
+      end
+
+      base_obj.addAttachment(soldier_obj)
+  end
+
+  base_obj.setRotation({0, y_rotation, 0})
+  base_obj.auto_raise = false
+end
+
+-- base: base base_definition
+-- pos: position where the base will be located
+-- y_rotation: in degrees
+-- is_red_player: Will the base belong to the red player
+-- common_color: color of the base edge, who ows the base.
 function spawn_base(base, pos, y_rotation, is_red_player, command_color)
     print_debug('Spawning base #' .. g_base_index)
     local overriden_tex = nil
@@ -113,7 +242,6 @@ function spawn_base(base, pos, y_rotation, is_red_player, command_color)
     end
     local base_name = 'base ' .. base['name'] .. ' #' .. g_base_index
     base_obj.setName(base_name)
-    add_context_menu_base(base_obj)
 
     g_base_index = g_base_index + 1
     g_bases[base_name] = {
@@ -133,83 +261,37 @@ function spawn_base(base, pos, y_rotation, is_red_player, command_color)
         end
     end
 
-    local n = base['n_models']
-    if n == 0 then
-        base_obj.setRotation({0, y_rotation, 0})
-        base_obj.auto_raise = false
-        return
-    end
-
-    local depth = get_depth_base(base['base'])
-    local half_depth = depth / 2
-    local half_width = g_base_width_in_inches / 2
-
-    local rows = 1
-    local columns = n
-    if n > 4 then
-        rows = math.floor(math.sqrt(n))
-        columns = math.ceil(n/rows)
-
-    end
-    local column_width = g_base_width_in_inches / (columns + 1)
-    local row_depth = depth / (rows + 1)
-
-    local model_name = base['model_data']
-    local meshes = {}
-
-    -- If the element has multiple nonfixed element, select randomly without
-    -- repeating
-    if model_name ~= nil then
-        meshes = calculate_random_meshes(n, _G[model_name]['mesh'])
-    end
-
-    for i=1,n do
-        local column = (i - 1) % columns + 1
-        local row = math.floor((i - 1) / columns) + 1
-
-        local random_rotation = math.random(0, 40) - 20
-        if str_has_substr(base_name, 'Camp') then
-            random_rotation = 0
-        end
-
-        local random_x = 0
-        local random_z = 0
-        if base['loose'] == true then
-            random_x = random_float(-g_max_loose_spawn, g_max_loose_spawn)
-            random_z = random_float(-g_max_loose_spawn, g_max_loose_spawn)
-        end
-
-        local relative_pos = {
-            x = pos['x'] + column * column_width - half_width + random_x,
-            y = pos['y'] + g_base_height_inches / 2,
-            z = pos['z'] + row * row_depth - half_depth + random_x
-        }
-
-        local this_model_name = model_name
-        local soldier_obj = nil
-        if this_model_name ~= nil then
-            -- The object has non-fixed models, so we use any of the
-            -- randomly selected meshes
-            soldier_obj = spawn_model(this_model_name, relative_pos, random_rotation, minimal_collider, is_red_player, nil, meshes[i])
-        else
-            -- Now we have fixed models, so we use the corresponding one
-            -- Except that fixed models may use assets instead of meshes!
-            this_model_name = base['fixed_models'][i]
-            if _G[this_model_name]['customasset'] ~= nil then
-                soldier_obj = spawn_asset(this_model_name, relative_pos, random_rotation)
-            else
-                meshes[i] = random_element(_G[this_model_name]['mesh'])
-                soldier_obj = spawn_model(this_model_name, relative_pos, random_rotation, minimal_collider, is_red_player, nil, meshes[i])
-            end
-        end
-
-        base_obj.addAttachment(soldier_obj)
-    end
-
-    base_obj.setRotation({0, y_rotation, 0})
-    base_obj.auto_raise = false
+    g_decorations[base_obj.getGUID()] = {
+      base_definition_name = base['base_definition_name'],
+      command_color = command_color,
+      is_red_player = is_red_player
+    }
+    add_models(base_name, base, base_obj, is_red_player, pos, y_rotation)
+    update_tool_tip(base_obj)
+    add_context_menu_base(base_obj)
     return base_obj
 end
+
+-- Get the base definition for an base object.
+-- base_obj:  Base object
+-- return: base definition or nil.
+function get_base_definition_from_base_obj(base_obj)
+  local decoration = g_decorations[ base_obj.getGUID()]
+  if nil == decoration then
+    return nil
+  end
+  local base_definition_name = decoration.base_definition_name
+  if nil == base_definition_name then
+    return nil
+  end
+  local base_definition = _G[base_definition_name]
+  if nil == base_definition_name then
+    print_error("base definition missing: " .. tostring(base_definition_name))
+    return nil
+  end
+  return base_definition
+end
+
 
 -- Get the definition for a base
 -- base_data:  If string is the name of the variable holding the definition,
@@ -277,7 +359,6 @@ function spawn_army(army_name, army, is_red_player, command_color)
                   z = row_z_pos - z_pos_modifier
               }
               local base_obj = spawn_base(base_definition, location, y_rotation, is_red_player, command_color)
-              g_decorations[base_obj.getGUID()] = {base_definition_name = base_definition['base_definition_name']}
               i = i + 1
             end
         end

--- a/scripts/logic_tool_tips.ttslua
+++ b/scripts/logic_tool_tips.ttslua
@@ -38,11 +38,22 @@ function get_battle_card_for_base_obj(base_obj)
   if nil == base_definition then
     return ""
   end
-  local battle_card = base_definition['battle_card']
-  if nil == battle_card then
-    return ""
+
+  local tip = ""
+  local dismounts_as = base_definition['dismount_as']
+  if dismounts_as ~= nil then
+    local dismounts_as_definition = _G[dismounts_as]
+    if nil ~= dismounts_as_definition then
+      local dismounts_name = dismounts_as_definition['name']
+      tip = "Dismounts as " .. dismounts_name .. "\n"
+    end
   end
-  return battle_card
+
+  local battle_card = base_definition['battle_card']
+  if nil ~= battle_card then
+    tip = tip .. battle_card
+  end
+  return tip
  end
 
 function get_tool_tip_for_base(base_obj)

--- a/scripts/logic_tool_tips.ttslua
+++ b/scripts/logic_tool_tips.ttslua
@@ -20,29 +20,22 @@ function toggle_tool_tips()
 end
 
 function update_tool_tips()
-print("IN update_tool_tips")
-  for _,base in pairs(get_all_bases()) do
-    print("Updating tool tip ", base.getName())
-    local tip = get_tool_tip_for_base(base)
-    base.setDescription(tip)
+  for _,base_obj in pairs(get_all_bases()) do
+    update_tool_tip(base_obj)
   end
-print("OUT update_tool_tips")
 end
 
--- base: base object 
+function update_tool_tip(base_obj)
+  local tip = get_tool_tip_for_base(base_obj)
+  base_obj.setDescription(tip)
+end
+
+
+-- base_obj: base object
 -- return: battle card for the base or empty string.
-function get_battle_card_for_base(base)
-  local decoration = g_decorations[ base.getGUID()]
-  if nil == decoration then
-    return ""
-  end
-  local base_definition_name = decoration.base_definition_name
-  if nil == base_definition_name then
-    return ""
-  end
-  local base_definition = _G[base_definition_name]
-  if nil == base_definition_name then
-    print_error("base definition missing: " .. tostring(base_definition_name))
+function get_battle_card_for_base_obj(base_obj)
+  local base_definition = get_base_definition_from_base_obj(base_obj)
+  if nil == base_definition then
     return ""
   end
   local battle_card = base_definition['battle_card']
@@ -52,16 +45,17 @@ function get_battle_card_for_base(base)
   return battle_card
  end
 
-function get_tool_tip_for_base(base)
-  if base == nil then
+function get_tool_tip_for_base(base_obj)
+  if base_obj == nil then
     return nil
   end
   if not g_tool_tips_enabled then
     return nil
   end
-  local tip =  
-    get_tool_tip_for_base_name(base.getName()) .. 
-    get_battle_card_for_base(base)
+  local base_name = base_obj.getName()
+  local tip =
+    get_tool_tip_for_base_name(base_name) ..
+    get_battle_card_for_base_obj(base_obj)
   return tip
 end
 

--- a/scripts/logic_tool_tips.ttslua
+++ b/scripts/logic_tool_tips.ttslua
@@ -20,11 +20,37 @@ function toggle_tool_tips()
 end
 
 function update_tool_tips()
+print("IN update_tool_tips")
   for _,base in pairs(get_all_bases()) do
+    print("Updating tool tip ", base.getName())
     local tip = get_tool_tip_for_base(base)
     base.setDescription(tip)
   end
+print("OUT update_tool_tips")
 end
+
+-- base: base object 
+-- return: battle card for the base or empty string.
+function get_battle_card_for_base(base)
+  local decoration = g_decorations[ base.getGUID()]
+  if nil == decoration then
+    return ""
+  end
+  local base_definition_name = decoration.base_definition_name
+  if nil == base_definition_name then
+    return ""
+  end
+  local base_definition = _G[base_definition_name]
+  if nil == base_definition_name then
+    print_error("base definition missing: " .. tostring(base_definition_name))
+    return ""
+  end
+  local battle_card = base_definition['battle_card']
+  if nil == battle_card then
+    return ""
+  end
+  return battle_card
+ end
 
 function get_tool_tip_for_base(base)
   if base == nil then
@@ -33,16 +59,19 @@ function get_tool_tip_for_base(base)
   if not g_tool_tips_enabled then
     return nil
   end
-  return get_tool_tip_for_base_name(base.getName())
+  local tip =  
+    get_tool_tip_for_base_name(base.getName()) .. 
+    get_battle_card_for_base(base)
+  return tip
 end
 
 function get_tool_tip_for_base_name(base_name)
   if base_name == nil then
-    return nil
+    return ""
   end
   local type = get_base_type_from_name(base_name)
   if type == nil then
-    return nil
+    return ""
   end
   return get_tool_tip(type)
 end
@@ -53,6 +82,7 @@ function get_base_type_from_name(base_name)
   if type == base_name then
     return nil -- no match.  this is an error
   end
+  type = str_remove_suffix(type, "*")
   type = str_remove_suffix(type, "_Gen")
   return type
 end

--- a/unittests/test_armies.lua
+++ b/unittests/test_armies.lua
@@ -82,16 +82,63 @@ function assert_base_name_valid(name, army_name, valid_names)
   lu.assertTrue(false)
 end
 
--- page 7 lists the abbreviations for the bases.  Verify only the correct
+-- Appendix A lists the abbreviations for the bases.  Verify only the correct
 -- abbreviations are used in the army lists.
-function test_bases_are_in_list()
+function test_bases_types_are_in_list()
   local valid_names = get_valid_base_names_triumph()
   for book_name, book in pairs(armies) do
     for army_name, army in pairs(armies[book_name]) do
       for k,v in pairs(army) do
-        if starts_with(k, "base") then
+        if not starts_with(k, "data") then
           local name = v.name
           assert_base_name_valid(name, army_name, valid_names)
+        end
+      end
+    end
+  end
+end
+
+-- If a base has points override then verify that the points is a 
+-- reasonable value
+function test_points_sane()
+  for book_name, book in pairs(armies) do
+    for army_name, army in pairs(armies[book_name]) do
+      for k,v in pairs(army) do
+        if not starts_with(k, "data") then
+          if nil ~= v['points'] then
+            lu.assertTrue(v.points >= 2)
+            lu.assertTrue(v.points <= 5)
+	  end
+        end
+      end
+    end
+  end
+end
+
+ -- Assert that the battle cards is valid
+function assert_battle_card_valid(base, army, key)
+  if base['battle_card'] == nil then
+    return 
+  end
+  if base.battle_card == 'Deployment Dismounting' then
+    return
+  end
+  if base.battle_card == 'Mobile Infantry' then
+    return
+  end
+  print("army: ", army)
+  print("base: ", key, ' ', base.name)
+  print("battle card: ", base['battle_card'])
+  lu.assertTrue(false)
+end
+
+-- If a base has a battle card check that it is valid
+function test_battle_cards_valid()
+  for book_name, book in pairs(armies) do
+    for army_name, army in pairs(armies[book_name]) do
+      for k,v in pairs(army) do
+        if not starts_with(k, "data") then
+          assert_battle_card_valid(v, army, k)
         end
       end
     end

--- a/unittests/test_armies.lua
+++ b/unittests/test_armies.lua
@@ -25,6 +25,7 @@ function remove_suffix(s, suffix)
 end
 
 function normalize_base_name(name)
+  name = remove_suffix(name, "*")
   name = remove_suffix(name, "_Gen")
   name = remove_suffix(name, "_Mobile")
   return name
@@ -91,8 +92,12 @@ function test_bases_types_are_in_list()
     for army_name, army in pairs(armies[book_name]) do
       for k,v in pairs(army) do
         if not starts_with(k, "data") then
-          local base_data = get_base_definition(v)
-          local name = base_data.name
+          local base_definition = get_base_definition(v)
+          if nil == base_definition then
+            print("get_base_definition failed for ", v)
+            lu.assertTrue(false)
+          end
+          local name = base_definition.name
           assert_base_name_valid(name, army_name, valid_names)
         end
       end

--- a/unittests/test_logic_tool_tips.lua
+++ b/unittests/test_logic_tool_tips.lua
@@ -1,5 +1,8 @@
 lu = require('externals/luaunit/luaunit')
+armies = {}
+require('scripts/data/data_armies_Medieval_Era')
 require('scripts/utilities_lua')
+require('scripts/utilities')
 require('scripts/logic_tool_tips')
 require('scripts/data/data_troops')
 require('scripts/data/data_cheat_sheet')
@@ -64,6 +67,29 @@ function test_build_tool_tip_target_close_combat_vs_mounted_missing()
     lu.assertTrue(actual)
 end
 
+function test_build_tool_tip_battle_card_added()
+    -- setup
+    local old_decorations = g_decorations
+    g_decorations = {}
+
+    local base = {
+        getName = function() return "Archers_Mobile" end,
+        getGUID = function() return "ABCDE" end,
+        base_definition_name = "burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted"
+    }
+    g_decorations[ base.getGUID() ] = {base_definition_name =  base.base_definition_name}
+
+    -- Exercise
+    local tip = get_tool_tip_for_base(base)
+
+    -- Verify
+    local actual = str_has_substr(tip, "Deployment Dismounting")
+    lu.assertTrue(actual)
+
+    -- Cleanup
+    g_decorations = old_decorations
+end
+
 function test_get_tool_tip_returns_nil_if_tool_tips_not_enabled()
     -- setup
     local orig = g_tool_tips_enabled
@@ -117,6 +143,14 @@ end
 
 function test_get_base_type_from_name_removes_general()
     local actual = get_base_type_from_name("base Archers_Gen # 3")
+    lu.assertEquals(actual, "Archers")
+end
+
+-- asterix is added to the name of a base to indicate that there
+-- is something special about it, and the tool tips should
+-- be consultex
+function test_get_base_type_from_name_removes_asterix()
+    local actual = get_base_type_from_name("base Archers_Gen* # 3")
     lu.assertEquals(actual, "Archers")
 end
 

--- a/unittests/test_logic_tool_tips.lua
+++ b/unittests/test_logic_tool_tips.lua
@@ -3,6 +3,7 @@ armies = {}
 require('scripts/data/data_armies_Medieval_Era')
 require('scripts/utilities_lua')
 require('scripts/utilities')
+require('scripts/logic_spawn_army')
 require('scripts/logic_tool_tips')
 require('scripts/data/data_troops')
 require('scripts/data/data_cheat_sheet')
@@ -77,13 +78,19 @@ function test_build_tool_tip_battle_card_added()
         getGUID = function() return "ABCDE" end,
         base_definition_name = "burgundian_ordannances_1471_to_1477_ad_knights_dd_mounted"
     }
+    assert(_G[base.base_definition_name] ~= nil)
     g_decorations[ base.getGUID() ] = {base_definition_name =  base.base_definition_name}
 
     -- Exercise
     local tip = get_tool_tip_for_base(base)
 
     -- Verify
-    local actual = str_has_substr(tip, "Deployment Dismounting")
+    local expected = "Deployment Dismounting"
+    local actual = str_has_substr(tip, expected)
+    if not actual then
+        print("expected: ", expected)
+        print("tip: ", tip)
+    end
     lu.assertTrue(actual)
 
     -- Cleanup


### PR DESCRIPTION
Add instructions to README.md on how to add an army

Burgundian Ordonnance modified to use base definitions, to be able to have the mapping from bases to the base definition.  Add "*" to the names of bases that have "Battle Cards" to indicate the tool tip is important.

Use decorator pattern to map bases to base definitions, saving and storing the map.

Add battle cards to tool tip.